### PR TITLE
Update versionx.class.php

### DIFF
--- a/core/components/versionx/model/versionx.class.php
+++ b/core/components/versionx/model/versionx.class.php
@@ -169,7 +169,7 @@ class VersionX {
             'content_id' => $rArray['id'],
             'user' => $this->modx->user->get('id'),
             'mode' => $mode,
-            'title' => $rArray[$this->modx->getOption('resource_tree_node_name',null,'pagetitle')],
+            'title' => (empty($rArray[$this->modx->getOption('resource_tree_node_name')]) ? $rArray['pagetitle'] : $rArray[$this->modx->getOption('resource_tree_node_name')]),
             'context_key' => $rArray['context_key'],
             'class' => $rArray['class_key'],
             'content' => $resource->get('content'),


### PR DESCRIPTION
This fixes the issue of getting blank titles when the system setting "resource_tree_node_name" is not set to pagetitle, and the field specified in that setting is blank in the resource being versioned.